### PR TITLE
Make CoinGeckoMarket.MarketCapRank property nullable

### DIFF
--- a/CoinGecko.Net/Objects/Models/CoinGeckoMarket.cs
+++ b/CoinGecko.Net/Objects/Models/CoinGeckoMarket.cs
@@ -39,7 +39,7 @@ namespace CoinGecko.Net.Objects.Models
         /// Market cap rank
         /// </summary>
         [JsonProperty("market_cap_rank")]
-        public decimal MarketCapRank { get; set; }
+        public decimal? MarketCapRank { get; set; }
         /// <summary>
         /// Fully diluted valuation
         /// </summary>


### PR DESCRIPTION
"https://api.coingecko.com/api/v3/coins/markets?ids=ethereum%2cethereum-wormhole&vs_currency=USD"

Gives the following error:

{Deserialize JsonSerializationException: Error converting value {null} to type 'System.Decimal'. Path '[1].market_cap_rank', line 1, position 1063. [Data only available in Trace LogLevel]}