### PR TITLE
Add missing CoinId and TargetCoinId fields to CoinGeckoDerivativeTicker model

### DIFF
--- a/CoinGecko.Net/CoinGecko.Net.xml
+++ b/CoinGecko.Net/CoinGecko.Net.xml
@@ -1994,6 +1994,16 @@
             Target asset
             </summary>
         </member>
+        <member name="P:CoinGecko.Net.Objects.Models.CoinGeckoDerivativeTicker.CoinId">
+            <summary>
+            Coin id
+            </summary>
+        </member>
+        <member name="P:CoinGecko.Net.Objects.Models.CoinGeckoDerivativeTicker.TargetCoinId">
+            <summary>
+            Target coin id
+            </summary>
+        </member>
         <member name="P:CoinGecko.Net.Objects.Models.CoinGeckoDerivativeTicker.TradeUrl">
             <summary>
             Trade url

--- a/CoinGecko.Net/Objects/Models/CoinGeckoDerivativeTicker.cs
+++ b/CoinGecko.Net/Objects/Models/CoinGeckoDerivativeTicker.cs
@@ -28,6 +28,16 @@ namespace CoinGecko.Net.Objects.Models
         [JsonPropertyName("target")]
         public string Target { get; set; } = string.Empty;
         /// <summary>
+        /// Coin id
+        /// </summary>
+        [JsonPropertyName("coin_id")]
+        public string? CoinId { get; set; }
+        /// <summary>
+        /// Target coin id
+        /// </summary>
+        [JsonPropertyName("target_coin_id")]
+        public string? TargetCoinId { get; set; }
+        /// <summary>
         /// Trade url
         /// </summary>
         [JsonPropertyName("trade_url")]


### PR DESCRIPTION
According to [CoinGecko documentation](https://docs.coingecko.com/v3.0.1/reference/derivatives-exchanges-id) the model [CoinGeckoDerivativeTicker](https://github.com/JKorf/CoinGecko.Net/blob/main/CoinGecko.Net/Objects/Models/CoinGeckoDerivativeTicker.cs) is missing "coin_id" and "target_coin_id" properties.
I've added them the same way they are present in [CoinGeckoTicker](https://github.com/JKorf/CoinGecko.Net/blob/main/CoinGecko.Net/Objects/Models/CoinGeckoTicker.cs) model