### PR TITLE
Updated CoinGeckoMarket AllTimeHighTimestamp and LastUpdated properties to nullable DateTime

### DIFF
--- a/CoinGecko.Net/Objects/Models/CoinGeckoMarket.cs
+++ b/CoinGecko.Net/Objects/Models/CoinGeckoMarket.cs
@@ -114,7 +114,7 @@ namespace CoinGecko.Net.Objects.Models
         /// </summary>
         [JsonConverter(typeof(DateTimeConverter))]
         [JsonPropertyName("ath_date")]
-        public DateTime AllTimeHighTimestamp { get; set; }
+        public DateTime? AllTimeHighTimestamp { get; set; }
         /// <summary>
         /// All time low price
         /// </summary>
@@ -141,7 +141,7 @@ namespace CoinGecko.Net.Objects.Models
         /// </summary>
         [JsonConverter(typeof(DateTimeConverter))]
         [JsonPropertyName("last_updated")]
-        public DateTime LastUpdated { get; set; }
+        public DateTime? LastUpdated { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
Fix for the `RestClient.Api.GetMarketsAsync(...)` request:
```
15:53:17.178 | Warning     | CryptoExchange | DateTime value of null, but property is not nullable. Resolver: CoinGeckoSourceGenerationContext
```

Example Json Data:

```json
....
    {
        "id": "atlas-2",
        "symbol": "atlas",
        "name": "ATLAS",
        "image": "https://coin-images.coingecko.com/coins/images/102172548/large/ATLAS.webp?1773830115",
        "current_price": null,
        "market_cap": null,
        "market_cap_rank": null,
        "fully_diluted_valuation": null,
        "total_volume": null,
        "high_24h": null,
        "low_24h": null,
        "price_change_24h": null,
        "price_change_percentage_24h": null,
        "market_cap_change_24h": null,
        "market_cap_change_percentage_24h": null,
        "circulating_supply": 0.0,
        "total_supply": 30000000.0,
        "max_supply": 30000000.0,
        "ath": null,
        "ath_change_percentage": 0.0,
        "ath_date": null,
        "atl": null,
        "atl_change_percentage": 0.0,
        "atl_date": null,
        "roi": null,
        "last_updated": null
    }
....
```